### PR TITLE
allow to choose baud rate for serial communication

### DIFF
--- a/src/arduino_exporter/cli.py
+++ b/src/arduino_exporter/cli.py
@@ -60,12 +60,20 @@ def server():
     default=8000,
     help="The HTTP server port",
 )
-def run(serial, port):
+@click.option(
+    "-b",
+    "--baud",
+    "baud",
+    type=click.INT,
+    default=9600,
+    help="The Serial communication baud rate",
+)
+def run(serial, baud, port):
     try:
         print(f"Starting server on port {port}")
         server = Server(int(port))
         prometheus = Prometheus()
-        serial = Serial(serial)
+        serial = Serial(serial, baud)
 
         server.add_callback(lambda: time.sleep(1))
         server.add_callback(lambda: prometheus.store(serial.read()))

--- a/src/arduino_exporter/serial.py
+++ b/src/arduino_exporter/serial.py
@@ -26,9 +26,9 @@ import serial
 class Serial:
     """Serial Class"""
 
-    def __init__(self, serial_port):
+    def __init__(self, serial_port, baud_rate):
         self._serial_port = serial_port
-        self._serial = serial.Serial(self._serial_port, 9800, timeout=1)
+        self._serial = serial.Serial(self._serial_port, baud_rate, timeout=1)
 
     def read(self):
         """


### PR DESCRIPTION
Adds the possibilty to choose the baud rate from the command line with the '-b' flag, If unspecified, the default is set to 9600 baud.

e.g. arduino_exporter server run -s /dev/ttyUSB0 -b 115200 -p 8080